### PR TITLE
Set up CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Test
+      run: cargo test --verbose

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -24,7 +24,7 @@
 // TODO: readme (rst? md? decide)
 // TODO: styling guide
 //       - mod/crate/use order
-// TODO: CI
+// TODO: improve CI (see PR #2)
 // TODO: tests
 // TODO: examples
 // TODO: publish on crates.io
@@ -37,6 +37,7 @@
 // TODO: migrate TODOs to GitHub issues/milestones
 // TODO: documentation + other repo setup
 // TODO: set github to default to rebasing instead of merges
+// TODO: consider fully migrating to GitLab, or as an ecosystem
 
 use std::collections::VecDeque;
 


### PR DESCRIPTION
This patch sets up GitHub Workflows to enable Cargo CI via GitHub Actions.

This CI could be drastically improved:
- Is there a better runner than ubuntu-latest? Perhaps freeze the Ubuntu version?
- Do we need to specify more with Cargo?
- Is there more we need to do? Do we also need to make sure future branches get their CI in order for backdated patch support?