### PR TITLE
bbu: change ArchInstruction to ArchMcrInst

### DIFF
--- a/src/bbu/chip8.rs
+++ b/src/bbu/chip8.rs
@@ -44,7 +44,7 @@ fn arg_is_register(a: &Option<Vec<String>> /*, p: usize*/) -> bool {
 
 macro_rules! gim {
     ($n:ident,$i:ident) => {{
-        Box::new(<chip8_raw::$n as crate::bbu::ArchInstruction<
+        Box::new(<chip8_raw::$n as crate::bbu::ArchMcrInst<
             chip8_raw::Chip8Symbol,
         >>::get_lex($i.args))
     }};
@@ -54,7 +54,7 @@ macro_rules! gim {
 // there's a lot of code duplication here
 pub fn get_instruction<T: crate::bbu::SymConv>(
     i: crate::parser::ParsedInstruction,
-) -> Box<dyn crate::bbu::ArchInstruction<T>> {
+) -> Box<dyn crate::bbu::ArchMcrInst<T>> {
     match i.instr.to_lowercase().as_str() {
         "mcr" => gim!(Chip8_0NNN, i),
         "cls" => gim!(Chip8_00E0, i),

--- a/src/bbu/chip8_raw.rs
+++ b/src/bbu/chip8_raw.rs
@@ -33,7 +33,7 @@ use std::str::FromStr;
 
 // TODO: better error handling
 // TODO: reduce repetition of this
-use crate::bbu::ArchInstruction;
+use crate::bbu::ArchMcrInst;
 use crate::bbu::ArchMacro;
 
 // TODO: push the shortening out throughout the file
@@ -94,13 +94,13 @@ impl<T: crate::bbu::SymConv> crate::bbu::ArchSym<T> for Chip8Symbol {
 
 macro_rules! gim {
     ($n:ident,$i:ident) => {{
-        Box::new(<$n as ArchInstruction<Chip8Symbol>>::get_lex($i.args))
+        Box::new(<$n as ArchMcrInst<Chip8Symbol>>::get_lex($i.args))
     }};
 }
 
 pub fn get_instruction<T: crate::bbu::SymConv>(
     i: crate::parser::ParsedInstruction,
-) -> Box<dyn ArchInstruction<T>> {
+) -> Box<dyn ArchMcrInst<T>> {
     match i.instr.to_lowercase().as_str() {
         // TODO: reduce code dup, tie into the macros beforehand??
         "0nnn" => gim!(Chip8_0NNN, i),
@@ -184,7 +184,7 @@ fn chip8_placeholder() -> Vec<u8> {
 macro_rules! make_std_const {
     ($nm:ident,$offs:expr) => {
         pub struct $nm {}
-        impl<T: crate::bbu::SymConv> ArchInstruction<T> for $nm {
+        impl<T: crate::bbu::SymConv> ArchMcrInst<T> for $nm {
             fn get_output_bytes(&self) -> Vec<u8> {
                 Vec::from($offs.to_be_bytes())
             }
@@ -210,7 +210,7 @@ macro_rules! make_std_nnn {
         pub struct $nm {
             addr: Chip8SymAlias,
         }
-        impl<T: crate::bbu::SymConv> ArchInstruction<T> for $nm {
+        impl<T: crate::bbu::SymConv> ArchMcrInst<T> for $nm {
             fn get_output_bytes(&self) -> Vec<u8> {
                 Vec::from(($offs | self.addr.unwrap_ptr().unwrap().i).to_be_bytes())
             }
@@ -257,7 +257,7 @@ macro_rules! make_std_xnn {
             x: Chip8ArchReg,
             d: Chip8SymAlias,
         }
-        impl<T: crate::bbu::SymConv> ArchInstruction<T> for $nm {
+        impl<T: crate::bbu::SymConv> ArchMcrInst<T> for $nm {
             fn get_output_bytes(&self) -> Vec<u8> {
                 Vec::from(
                     ($offs | ((self.x.n as u16) << 8) | (self.d.unwrap_data().unwrap().i as u16))
@@ -303,7 +303,7 @@ macro_rules! make_std_xy {
             s: Chip8ArchReg,
             d: Chip8ArchReg,
         }
-        impl<T: crate::bbu::SymConv> ArchInstruction<T> for $nm {
+        impl<T: crate::bbu::SymConv> ArchMcrInst<T> for $nm {
             fn get_output_bytes(&self) -> Vec<u8> {
                 Vec::from(
                     ($offs | ((self.d.n as u16) << 8) | ((self.s.n as u16) << 4)).to_be_bytes(),
@@ -338,7 +338,7 @@ macro_rules! make_std_xyn {
             x: Chip8ArchReg,
             y: Chip8ArchReg,
         }
-        impl<T: crate::bbu::SymConv> ArchInstruction<T> for $nm {
+        impl<T: crate::bbu::SymConv> ArchMcrInst<T> for $nm {
             fn get_output_bytes(&self) -> Vec<u8> {
                 // TODO: warn on overflow
                 Vec::from(
@@ -392,7 +392,7 @@ macro_rules! make_std_efx {
         pub struct $nm {
             x: Chip8ArchReg,
         }
-        impl<T: crate::bbu::SymConv> ArchInstruction<T> for $nm {
+        impl<T: crate::bbu::SymConv> ArchMcrInst<T> for $nm {
             fn get_output_bytes(&self) -> Vec<u8> {
                 Vec::from(($offs | ((self.x.n as u16) << 8)).to_be_bytes())
             }

--- a/src/bbu/mod.rs
+++ b/src/bbu/mod.rs
@@ -76,14 +76,14 @@ pub trait ArchSym<T: SymConv> {
 }
 
 // TODO: really hate using vecs for this
-pub trait ArchInstruction<T: SymConv> {
+pub trait ArchMcrInst<T: SymConv> {
     fn get_output_bytes(&self) -> Vec<u8>;
     fn check_symbols(&self) -> bool;
     fn get_symbols(&self) -> Option<Vec<UnresSymInfo>>;
     fn get_placeholder(&self) -> Vec<u8>;
     // NOTE: should this return Result<>? Shouldn't be able to fail...
     fn fulfill_symbol(&mut self, s: &T, p: SymbolPosition) -> ();
-    // TODO: is it better to put Sized in the ArchInstruction definition?
+    // TODO: is it better to put Sized in the ArchMcrInst definition?
     fn get_lex(a: Option<Vec<String>>) -> Self
     where
         Self: Sized;

--- a/src/bbu/outs/mod.rs
+++ b/src/bbu/outs/mod.rs
@@ -29,7 +29,7 @@ pub type LabelTree<T> = std::collections::HashMap<String, T>;
 // TODO: fix inherent cloning issues with String
 // also, TODO: it is absolutely not necessary for these to be ordered
 // T = crate::bbu::SymConv, U = crate::bbu::PTR_SIZE
-pub type UnresSymTree<T, U> = Vec<(Box<dyn crate::bbu::ArchInstruction<T>>, U)>;
+pub type UnresSymTree<T, U> = Vec<(Box<dyn crate::bbu::ArchMcrInst<T>>, U)>;
 
 // TODO NOTE: utility function
 // o = offset

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -66,7 +66,7 @@ use crate::errors::lpanic;
 // type from platform.
 
 pub enum LexOperation<T: crate::bbu::SymConv> {
-    Instruction(Box<dyn crate::bbu::ArchInstruction<T>>),
+    Instruction(Box<dyn crate::bbu::ArchMcrInst<T>>),
     Macro(Box<dyn crate::bbu::ArchMacro>),
 }
 
@@ -74,7 +74,7 @@ impl<T: crate::bbu::SymConv> std::fmt::Debug for LexOperation<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             LexOperation::Instruction(ref i) => {
-                write!(f, "ArchInstruction: {:02x?}", i.get_output_bytes())
+                write!(f, "ArchMcrInst: {:02x?}", i.get_output_bytes())
             }
             LexOperation::Macro(ref j) => write!(f, "ArchMacro: {:02x?}", j.get_output_bytes()),
         }


### PR DESCRIPTION
This patch helps reflect the changes coming in #13. Since ArchInstruction is going to be used for both post-lex macros and instructions, this change provides a better reflection. After #13, ArchMacro will cease to exist anyways, removing any confusion.

Since this patch is minor, it does not need review.

Fixes: #14
Signed-off-by: Amy Parker <apark0006@student.cerritos.edu>