### PR TITLE
add featurization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,9 @@ path = "src/lib.rs"
 
 [badges]
 maintenance = { status = "actively-developed" }
+
+[features]
+default = ["rawbin", "chip8", "chip8-raw"]
+rawbin = []
+chip8-raw = []
+chip8 = ["chip8-raw"]

--- a/src/bbu/mod.rs
+++ b/src/bbu/mod.rs
@@ -52,11 +52,12 @@
 //       ties into license declaration perhaps
 
 // TODO: generic argument types (direct, label, memory, register, etc)
-// TODO: general symbol implementation
 
 use crate::errors::lpanic;
 
+#[cfg(feature = "chip8")]
 pub mod chip8;
+#[cfg(feature = "chip8-raw")]
 pub mod chip8_raw;
 pub mod outs;
 

--- a/src/bbu/outs/mod.rs
+++ b/src/bbu/outs/mod.rs
@@ -21,6 +21,7 @@
  * <https://gnu.org/licenses/old-licenses/gpl-2.0.html>.
  */
 
+#[cfg(feature = "rawbin")]
 pub mod rawbin;
 
 // T = crate::bbu::SymConv
@@ -48,8 +49,9 @@ pub fn run_output<T: crate::bbu::SymConv, U: crate::bbu::PtrSize>(
 ) -> () {
     // each combination could need something different, so each is explicit
     // TODO generate this with macros
-    (match plat.target {
-        crate::platform::PlatformTarget::RawBinary => rawbin::run_output::<T, U>,
+    match plat.target {
+        #[cfg(feature = "rawbin")]
+        crate::platform::PlatformTarget::RawBinary => rawbin::run_output::<T, U>(src, dest, plat),
         //_ => panic!("unsupported combination"),
-    })(src, dest, plat);
+    }
 }

--- a/src/bbu/outs/rawbin.rs
+++ b/src/bbu/outs/rawbin.rs
@@ -111,9 +111,12 @@ pub fn run_output<T: crate::bbu::SymConv, U: crate::bbu::PtrSize>(
 
 // TODO: move offsets into another part of BBU maybe? probably arch pages?
 pub fn get_offset<T: crate::bbu::PtrSize>(p: &crate::platform::Platform) -> T {
+    #[allow(unreachable_patterns)]
     match &p.arch {
+        #[cfg(feature = "chip8-raw")]
         crate::platform::PlatformArch::ChipEightRaw => T::from_int(0x200),
+        #[cfg(feature = "chip8")]
         crate::platform::PlatformArch::ChipEight => T::from_int(0x200),
-        //_ => panic!("unknown arch"),
+        _ => panic!("unknown arch"),
     }
 }

--- a/src/eaf.rs
+++ b/src/eaf.rs
@@ -41,14 +41,16 @@ pub fn assemble_full_source(src: &String, pl: &crate::platform::Platform) -> Vec
     let mut p: crate::parser::Parser = crate::parser::Parser::from_str(src).unwrap();
     p.parse_all();
     // if only rust could return types from matches...
-    (match pl.arch {
+    match pl.arch {
+        #[cfg(feature = "chip8-raw")]
         crate::platform::PlatformArch::ChipEightRaw | crate::platform::PlatformArch::ChipEight => {
             assemble_full_source_gen::<
                 crate::bbu::chip8_raw::Chip8Symbol,
                 crate::bbu::chip8_raw::Chip8PtrSize,
-            >
+            >(p.pop_vdq(), pl)
         }
-    })(p.pop_vdq(), pl)
+        //_ => panic!("unknown arch")
+    }
 }
 
 // naturally handles lexer-onwards

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -303,13 +303,15 @@ impl<T: crate::bbu::SymConv> Lexer<T> {
     fn push_macro(&mut self, i: crate::parser::ParsedMacro) {
         if let Some(ref mut j) = &mut self.cl {
             let op: LexOperation<T> = match self.p.arch {
+                #[cfg(feature = "chip8-raw")]
                 crate::platform::PlatformArch::ChipEightRaw => {
                     LexOperation::Macro(crate::bbu::chip8_raw::get_macro(i))
                 }
+                #[cfg(feature = "chip8")]
                 crate::platform::PlatformArch::ChipEight => {
                     LexOperation::Macro(crate::bbu::chip8::get_macro(i))
                 }
-                // _ => panic!("not implemented yet")
+                //_ => panic!("not implemented yet")
             };
             match j {
                 LexLabelType::Base(ref mut a) => a,
@@ -329,12 +331,15 @@ impl<T: crate::bbu::SymConv> Lexer<T> {
             // FIXME consider removing it in cleanup
             // TODO: move this responsibility over to BBU global thanks to ArchArg
             let op: LexOperation<T> = match self.p.arch {
+                #[cfg(feature = "chip8-raw")]
                 crate::platform::PlatformArch::ChipEightRaw => {
                     LexOperation::Instruction(crate::bbu::chip8_raw::get_instruction::<T>(i))
                 }
+                #[cfg(feature = "chip8")]
                 crate::platform::PlatformArch::ChipEight => {
                     LexOperation::Instruction(crate::bbu::chip8::get_instruction::<T>(i))
-                } //_ => panic!("architecture not implemented yet"),
+                }
+                //_ => panic!("architecture not implemented yet"),
             };
             match j {
                 LexLabelType::Base(ref mut a) => a,

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -25,12 +25,15 @@ use crate::errors::lpanic;
 
 #[derive(Clone, Debug)]
 pub enum PlatformArch {
+    #[cfg(feature = "chip8-raw")]
     ChipEightRaw,
+    #[cfg(feature = "chip8")]
     ChipEight,
 }
 
 #[derive(Clone, Debug)]
 pub enum PlatformTarget {
+    #[cfg(feature = "rawbin")]
     RawBinary,
 }
 
@@ -52,11 +55,14 @@ impl Platform {
         Platform {
             // TODO: consider using some kind of lookup table?
             arch: match arch.to_lowercase().as_str() {
+                #[cfg(feature = "chip8-raw")]
                 "chipeightraw" | "chip8raw" | "c8r" | "chip8r" => PlatformArch::ChipEightRaw,
+                #[cfg(feature = "chip8")]
                 "chipeight" | "chip8" | "c8" => PlatformArch::ChipEight,
                 _ => lpanic("unsupported arch"),
             },
             target: match target.to_lowercase().as_str() {
+                #[cfg(feature = "rawbin")]
                 "bin" | "binary" | "raw" | "rawbin" | "rawbinary" => PlatformTarget::RawBinary,
                 _ => lpanic("unsupported target"),
             },
@@ -69,7 +75,9 @@ impl Platform {
     // True = little, False = big
     pub fn get_endianness(&self) -> bool {
         match self.arch {
+            #[cfg(feature = "chip8")]
             PlatformArch::ChipEight => false,
+            #[cfg(feature = "chip8-raw")]
             PlatformArch::ChipEightRaw => false,
             // _ => lpanic("unsupported arch")
         }


### PR DESCRIPTION
This patch adds featurization to libxas. Currently, there are three features - chip8, chip8-raw, and rawbin - which are all enabled by default. There's still a lot of work to do, but this patch upgrades the crate significantly.

Signed-off-by: Amy Parker <apark0006@student.cerritos.edu>