### PR TITLE
bbu: use option trees for symbol resolution

### DIFF
--- a/src/bbu/chip8.rs
+++ b/src/bbu/chip8.rs
@@ -118,8 +118,6 @@ pub fn get_instruction<T: crate::bbu::SymConv>(
     }
 }
 
-pub fn get_macro(
-    i: crate::parser::ParsedMacro
-) -> Box<dyn ArchMacro> {
+pub fn get_macro(i: crate::parser::ParsedMacro) -> Box<dyn ArchMacro> {
     chip8_raw::get_macro(i)
 }

--- a/src/bbu/chip8_raw.rs
+++ b/src/bbu/chip8_raw.rs
@@ -41,6 +41,8 @@ use crate::bbu::ArchMacro;
 use crate::bbu::DatSize;
 use crate::bbu::PtrSize;
 
+use crate::bbu::RcSym;
+
 pub type Chip8DatSize = crate::bbu::GenScal<u8>;
 // TODO: generic displacement size for types without one
 // (@u8 for size)
@@ -79,10 +81,10 @@ impl crate::bbu::SymConv for Chip8Symbol {
 }
 
 impl<T: crate::bbu::SymConv> crate::bbu::ArchSym<T> for Chip8Symbol {
-    fn get_uk_sym(&self) -> Option<&String> {
+    fn get_uk_sym(&self) -> Option<RcSym> {
         match &self.i {
             crate::bbu::ArgSymbol::UnknownPointer(i) | crate::bbu::ArgSymbol::UnknownData(i) => {
-                Some(i)
+                Some(i.clone())
             }
             _ => None,
         }
@@ -197,10 +199,13 @@ macro_rules! make_std_const {
             fn check_symbols(&self) -> bool {
                 false
             }
-            fn get_symbols(&self) -> Option<Vec<(&String, crate::bbu::SymbolPosition)>> {
+            // TODO: replace tuple with UnresSymInfo
+            fn get_symbols(&self) -> Option<Vec<(RcSym, crate::bbu::SymbolPosition)>> {
                 None
             }
-            fn get_length(&self) -> crate::bbu::SymbolPosition {CHIP8_INSTR_LEN}
+            fn get_length(&self) -> crate::bbu::SymbolPosition {
+                CHIP8_INSTR_LEN
+            }
             fn get_placeholder(&self) -> Vec<u8> {
                 chip8_placeholder()
             }
@@ -227,14 +232,16 @@ macro_rules! make_std_nnn {
                     _ => false,
                 }
             }
-            fn get_symbols(&self) -> Option<Vec<(&String, crate::bbu::SymbolPosition)>> {
+            fn get_symbols(&self) -> Option<Vec<(RcSym, crate::bbu::SymbolPosition)>> {
                 let r = match self.addr {
-                    crate::bbu::ArgSymbol::UnknownPointer(ref a) => Some(vec![(a, 0)]),
+                    crate::bbu::ArgSymbol::UnknownPointer(ref a) => Some(vec![(a.clone(), 0)]),
                     _ => None,
                 };
                 r
             }
-            fn get_length(&self) -> crate::bbu::SymbolPosition {CHIP8_INSTR_LEN}
+            fn get_length(&self) -> crate::bbu::SymbolPosition {
+                CHIP8_INSTR_LEN
+            }
             fn get_placeholder(&self) -> Vec<u8> {
                 chip8_placeholder()
             }
@@ -279,13 +286,15 @@ macro_rules! make_std_xnn {
                     _ => false,
                 }
             }
-            fn get_symbols(&self) -> Option<Vec<(&String, crate::bbu::SymbolPosition)>> {
+            fn get_symbols(&self) -> Option<Vec<(RcSym, crate::bbu::SymbolPosition)>> {
                 match self.d {
-                    crate::bbu::ArgSymbol::UnknownData(ref a) => Some(vec![(a, 0)]),
+                    crate::bbu::ArgSymbol::UnknownData(ref a) => Some(vec![(a.clone(), 0)]),
                     _ => None,
                 }
             }
-            fn get_length(&self) -> crate::bbu::SymbolPosition {CHIP8_INSTR_LEN}
+            fn get_length(&self) -> crate::bbu::SymbolPosition {
+                CHIP8_INSTR_LEN
+            }
             fn get_placeholder(&self) -> Vec<u8> {
                 chip8_placeholder()
             }
@@ -323,10 +332,12 @@ macro_rules! make_std_xy {
             fn check_symbols(&self) -> bool {
                 false
             }
-            fn get_symbols(&self) -> Option<Vec<(&String, crate::bbu::SymbolPosition)>> {
+            fn get_symbols(&self) -> Option<Vec<(RcSym, crate::bbu::SymbolPosition)>> {
                 None
             }
-            fn get_length(&self) -> crate::bbu::SymbolPosition {CHIP8_INSTR_LEN}
+            fn get_length(&self) -> crate::bbu::SymbolPosition {
+                CHIP8_INSTR_LEN
+            }
             fn get_placeholder(&self) -> Vec<u8> {
                 chip8_placeholder()
             }
@@ -370,13 +381,15 @@ macro_rules! make_std_xyn {
                     _ => false,
                 }
             }
-            fn get_symbols(&self) -> Option<Vec<(&String, crate::bbu::SymbolPosition)>> {
+            fn get_symbols(&self) -> Option<Vec<(RcSym, crate::bbu::SymbolPosition)>> {
                 match self.n {
-                    crate::bbu::ArgSymbol::UnknownData(ref a) => Some(vec![(a, 0)]),
+                    crate::bbu::ArgSymbol::UnknownData(ref a) => Some(vec![(a.clone(), 0)]),
                     _ => None,
                 }
             }
-            fn get_length(&self) -> crate::bbu::SymbolPosition {CHIP8_INSTR_LEN}
+            fn get_length(&self) -> crate::bbu::SymbolPosition {
+                CHIP8_INSTR_LEN
+            }
             fn get_placeholder(&self) -> Vec<u8> {
                 chip8_placeholder()
             }
@@ -411,10 +424,12 @@ macro_rules! make_std_efx {
             fn check_symbols(&self) -> bool {
                 false
             }
-            fn get_symbols(&self) -> Option<Vec<(&String, crate::bbu::SymbolPosition)>> {
+            fn get_symbols(&self) -> Option<Vec<(RcSym, crate::bbu::SymbolPosition)>> {
                 None
             }
-            fn get_length(&self) -> crate::bbu::SymbolPosition {CHIP8_INSTR_LEN}
+            fn get_length(&self) -> crate::bbu::SymbolPosition {
+                CHIP8_INSTR_LEN
+            }
             fn get_placeholder(&self) -> Vec<u8> {
                 chip8_placeholder()
             }
@@ -479,9 +494,9 @@ fn get_nnn(a: Option<Vec<String>>) -> Chip8SymAlias {
 fn get_xnn(a: Option<Vec<String>>) -> (Chip8ArchReg, Chip8SymAlias) {
     let b: Vec<Chip8Arg> = argcheck(&a, 2);
     (
-            *b[1].unwrap_register().unwrap().reg,
-            // TODO: also avoid this clone
-            b[0].unwrap_direct().unwrap().clone(),
+        *b[1].unwrap_register().unwrap().reg,
+        // TODO: also avoid this clone
+        b[0].unwrap_direct().unwrap().clone(),
     )
     /*
     if let Some(ref i) = a {
@@ -557,16 +572,14 @@ fn argcheck(a: &Option<Vec<String>>, i: usize) -> Vec<Chip8Arg> {
 macro_rules! gmm {
     ($n:ident,$i:ident) => {{
         Box::new(<crate::bbu::$n as ArchMacro>::get_lex($i.args))
-    }}
+    }};
 }
 
 // TODO: consider putting these in lexer maybe? idk
 // TODO FIXME: add symbols to macros
-pub fn get_macro(
-    i: crate::parser::ParsedMacro,
-) -> Box<dyn ArchMacro> {
+pub fn get_macro(i: crate::parser::ParsedMacro) -> Box<dyn ArchMacro> {
     match i.mcr.to_lowercase().as_str() {
         "byte" => gmm!(BigByte, i),
-        _ => lpanic("macro not supported")
+        _ => lpanic("macro not supported"),
     }
 }

--- a/src/bbu/chip8_raw.rs
+++ b/src/bbu/chip8_raw.rs
@@ -179,6 +179,9 @@ fn chip8_placeholder() -> Vec<u8> {
     vec![0u8, 0u8]
 }
 
+// TODO: review of public vs pub(crate) vs private api
+const CHIP8_INSTR_LEN: u8 = 2u8;
+
 // lots of code duplication with get_output_bytes TODO FIXME NOTE, somen with get_lex
 
 macro_rules! make_std_const {
@@ -197,6 +200,7 @@ macro_rules! make_std_const {
             fn get_symbols(&self) -> Option<Vec<(&String, crate::bbu::SymbolPosition)>> {
                 None
             }
+            fn get_length(&self) -> crate::bbu::SymbolPosition {CHIP8_INSTR_LEN}
             fn get_placeholder(&self) -> Vec<u8> {
                 chip8_placeholder()
             }
@@ -230,6 +234,7 @@ macro_rules! make_std_nnn {
                 };
                 r
             }
+            fn get_length(&self) -> crate::bbu::SymbolPosition {CHIP8_INSTR_LEN}
             fn get_placeholder(&self) -> Vec<u8> {
                 chip8_placeholder()
             }
@@ -280,6 +285,7 @@ macro_rules! make_std_xnn {
                     _ => None,
                 }
             }
+            fn get_length(&self) -> crate::bbu::SymbolPosition {CHIP8_INSTR_LEN}
             fn get_placeholder(&self) -> Vec<u8> {
                 chip8_placeholder()
             }
@@ -320,6 +326,7 @@ macro_rules! make_std_xy {
             fn get_symbols(&self) -> Option<Vec<(&String, crate::bbu::SymbolPosition)>> {
                 None
             }
+            fn get_length(&self) -> crate::bbu::SymbolPosition {CHIP8_INSTR_LEN}
             fn get_placeholder(&self) -> Vec<u8> {
                 chip8_placeholder()
             }
@@ -369,6 +376,7 @@ macro_rules! make_std_xyn {
                     _ => None,
                 }
             }
+            fn get_length(&self) -> crate::bbu::SymbolPosition {CHIP8_INSTR_LEN}
             fn get_placeholder(&self) -> Vec<u8> {
                 chip8_placeholder()
             }
@@ -406,6 +414,7 @@ macro_rules! make_std_efx {
             fn get_symbols(&self) -> Option<Vec<(&String, crate::bbu::SymbolPosition)>> {
                 None
             }
+            fn get_length(&self) -> crate::bbu::SymbolPosition {CHIP8_INSTR_LEN}
             fn get_placeholder(&self) -> Vec<u8> {
                 chip8_placeholder()
             }

--- a/src/bbu/mod.rs
+++ b/src/bbu/mod.rs
@@ -80,6 +80,11 @@ pub trait ArchInstruction<T: SymConv> {
     fn get_output_bytes(&self) -> Vec<u8>;
     fn check_symbols(&self) -> bool;
     fn get_symbols(&self) -> Option<Vec<UnresSymInfo>>;
+    fn get_length(&self) -> SymbolPosition;
+    // TODO: deprecate? (general project cleaning/deprecation)
+    // TODO: feature `no-deprecated`, removes all deprecated code
+    // TODO: feature `no-log`, removes logging
+    // NOTE: maybe do the same for colored logging?
     fn get_placeholder(&self) -> Vec<u8>;
     // NOTE: should this return Result<>? Shouldn't be able to fail...
     fn fulfill_symbol(&mut self, s: &T, p: SymbolPosition) -> ();

--- a/src/bbu/outs/mod.rs
+++ b/src/bbu/outs/mod.rs
@@ -29,17 +29,18 @@ pub type LabelTree<T> = std::collections::HashMap<String, T>;
 // TODO: fix inherent cloning issues with String
 // also, TODO: it is absolutely not necessary for these to be ordered
 // T = crate::bbu::SymConv, U = crate::bbu::PTR_SIZE
-pub type UnresSymTree<T, U> = Vec<(Box<dyn crate::bbu::ArchInstruction<T>>, U)>;
+//pub type UnresSymTree<T, U> = Vec<(Box<dyn crate::bbu::ArchInstruction<T>>, U)>;
 
 // TODO NOTE: utility function
 // o = offset
+/*
 pub fn vec_update(s: &Vec<u8>, d: &mut Vec<u8>, o: usize) -> () {
     // TODO: make this more efficient, this is slow asf
     // also, TODO: make this work for Vec<T: Integral>
     for e in 0..s.len() {
         d[o + e] = s[e];
     }
-}
+}*/
 
 pub fn run_output<T: crate::bbu::SymConv, U: crate::bbu::PtrSize>(
     src: Vec<crate::lexer::LexSection<T>>,

--- a/src/bbu/outs/rawbin.rs
+++ b/src/bbu/outs/rawbin.rs
@@ -117,7 +117,7 @@ pub fn run_output<T: crate::bbu::SymConv, U: crate::bbu::PtrSize>(
 // TODO: make OptionLeaf a globally available concept
 enum OptionLeaf<T: crate::bbu::SymConv> {
     Constant(Vec<u8>),
-    Symbol(Box<dyn crate::bbu::ArchInstruction<T>>),
+    Symbol(Box<dyn crate::bbu::ArchMcrInst<T>>),
 }
 
 type VecOptTree<T> = Vec<OptionLeaf<T>>;

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -308,13 +308,13 @@ impl<T: crate::bbu::SymConv> Lexer<T> {
                 }
                 crate::platform::PlatformArch::ChipEight => {
                     LexOperation::Macro(crate::bbu::chip8::get_macro(i))
-                }
-                // _ => panic!("not implemented yet")
+                } // _ => panic!("not implemented yet")
             };
             match j {
                 LexLabelType::Base(ref mut a) => a,
                 LexLabelType::Std(ref mut b) => &mut b.ops,
-            }.push(op);
+            }
+            .push(op);
         }
     }
 


### PR DESCRIPTION
This patch by using Option trees greatly improves the performance of symbol resolution. It can be made slightly more efficient if `Arc<String>` is turned into `Arc<str>`, although the time offset of the conversion does need to be studied.

Fixes: #15 
Signed-off-by: Amy Parker <apark0006@student.cerritos.edu>