### PR TITLE
bbu: RcSym upgrade and USIWrap modification

### DIFF
--- a/src/bbu/chip8_raw.rs
+++ b/src/bbu/chip8_raw.rs
@@ -200,7 +200,7 @@ macro_rules! make_std_const {
                 false
             }
             // TODO: replace tuple with UnresSymInfo
-            fn get_symbols(&self) -> Option<Vec<(RcSym, crate::bbu::SymbolPosition)>> {
+            fn get_symbols(&self) -> crate::bbu::USIWrap {
                 None
             }
             fn get_length(&self) -> crate::bbu::SymbolPosition {
@@ -232,7 +232,7 @@ macro_rules! make_std_nnn {
                     _ => false,
                 }
             }
-            fn get_symbols(&self) -> Option<Vec<(RcSym, crate::bbu::SymbolPosition)>> {
+            fn get_symbols(&self) -> crate::bbu::USIWrap {
                 let r = match self.addr {
                     crate::bbu::ArgSymbol::UnknownPointer(ref a) => Some(vec![(a.clone(), 0)]),
                     _ => None,
@@ -286,7 +286,7 @@ macro_rules! make_std_xnn {
                     _ => false,
                 }
             }
-            fn get_symbols(&self) -> Option<Vec<(RcSym, crate::bbu::SymbolPosition)>> {
+            fn get_symbols(&self) -> crate::bbu::USIWrap {
                 match self.d {
                     crate::bbu::ArgSymbol::UnknownData(ref a) => Some(vec![(a.clone(), 0)]),
                     _ => None,
@@ -332,7 +332,7 @@ macro_rules! make_std_xy {
             fn check_symbols(&self) -> bool {
                 false
             }
-            fn get_symbols(&self) -> Option<Vec<(RcSym, crate::bbu::SymbolPosition)>> {
+            fn get_symbols(&self) -> crate::bbu::USIWrap {
                 None
             }
             fn get_length(&self) -> crate::bbu::SymbolPosition {
@@ -381,7 +381,7 @@ macro_rules! make_std_xyn {
                     _ => false,
                 }
             }
-            fn get_symbols(&self) -> Option<Vec<(RcSym, crate::bbu::SymbolPosition)>> {
+            fn get_symbols(&self) -> crate::bbu::USIWrap {
                 match self.n {
                     crate::bbu::ArgSymbol::UnknownData(ref a) => Some(vec![(a.clone(), 0)]),
                     _ => None,
@@ -424,7 +424,7 @@ macro_rules! make_std_efx {
             fn check_symbols(&self) -> bool {
                 false
             }
-            fn get_symbols(&self) -> Option<Vec<(RcSym, crate::bbu::SymbolPosition)>> {
+            fn get_symbols(&self) -> crate::bbu::USIWrap {
                 None
             }
             fn get_length(&self) -> crate::bbu::SymbolPosition {

--- a/src/bbu/mod.rs
+++ b/src/bbu/mod.rs
@@ -292,7 +292,7 @@ fn parse_ukr<T: Integral>(s: &str) -> Option<T> {
 pub trait ArchReg: Copy + Clone + std::str::FromStr<Err = std::num::ParseIntError> + Sized {}
 
 // TODO: migrate to Rc<str> to avoid cache misses
-pub type RcSym = std::rc::Rc<String>;
+pub type RcSym = std::rc::Rc<str>;
 
 #[derive(Clone)]
 pub enum ArgSymbol<T: PtrSize, U: DatSize> {
@@ -304,17 +304,17 @@ pub enum ArgSymbol<T: PtrSize, U: DatSize> {
 
 // condense these unwrapper functions TODO
 impl<T: PtrSize, U: DatSize> ArgSymbol<T, U> {
-    pub fn unwrap_unknown_ptr(&self) -> Option<&String> {
+    pub fn unwrap_unknown_ptr(&self) -> Option<RcSym> {
         if let ArgSymbol::UnknownPointer(n) = self {
-            return Some(n);
+            return Some(n.clone());
         } else {
             return None;
         }
     }
 
-    pub fn unwrap_unknown_data(&self) -> Option<&String> {
+    pub fn unwrap_unknown_data(&self) -> Option<RcSym> {
         if let ArgSymbol::UnknownData(n) = self {
-            return Some(n);
+            return Some(n.clone());
         } else {
             return None;
         }
@@ -458,7 +458,7 @@ fn get_direct_value<T: PtrSize, U: DatSize>(s: &String) -> ArgSymbol<T, U> {
     if s.chars().next().unwrap().is_numeric() {
         return ArgSymbol::Data(Box::new(U::from_str(s).unwrap()));
     } else {
-        return ArgSymbol::UnknownData(RcSym::new(s.clone()));
+        return ArgSymbol::UnknownData(RcSym::from(s.as_str()));
     }
 }
 
@@ -511,7 +511,7 @@ fn extract_mem_symbol<T: PtrSize, U: DatSize>(s: &String) -> ArgSymbol<T, U> {
     if ns.chars().next().unwrap().is_numeric() || ns.chars().next().unwrap() == '-' {
         return ArgSymbol::Pointer(Box::new(T::from_str(&ns).unwrap()));
     } else {
-        return ArgSymbol::UnknownPointer(RcSym::new(ns));
+        return ArgSymbol::UnknownPointer(RcSym::from(ns.as_str()));
     }
 }
 

--- a/src/bbu/mod.rs
+++ b/src/bbu/mod.rs
@@ -63,7 +63,7 @@ pub mod outs;
 
 pub type SymbolPosition = u8;
 
-pub type UnresSymInfo<'a> = (RcSym, SymbolPosition);
+pub type USIWrap = Option<Vec<(RcSym, SymbolPosition)>>;
 
 pub trait SymConv {
     fn from_ptr<T: PtrSize>(a: T) -> Self;
@@ -80,7 +80,7 @@ pub trait ArchSym<T: SymConv> {
 pub trait ArchMcrInst<T: SymConv> {
     fn get_output_bytes(&self) -> Vec<u8>;
     fn check_symbols(&self) -> bool;
-    fn get_symbols(&self) -> Option<Vec<UnresSymInfo>>;
+    fn get_symbols(&self) -> USIWrap;
     fn get_length(&self) -> SymbolPosition;
     // TODO: deprecate? (general project cleaning/deprecation)
     // TODO: feature `no-deprecated`, removes all deprecated code


### PR DESCRIPTION
This patch upgrades RcSym performance-wise to use Rc<str> instead of Rc<String>, avoiding indrection and giving an actual chance of a cache hit. It also simplifies function signatures using a new USIWrap type, which avoids the cluttered mess of the previous UnresSymInfo interpretation which was not widely followed (including in c8r!)

Signed-off-by: Amy Parker <apark0006@student.cerritos.edu>