### PR TITLE
add basics for logging

### DIFF
--- a/src/bbu/outs/rawbin.rs
+++ b/src/bbu/outs/rawbin.rs
@@ -131,7 +131,7 @@ fn get_offset<T: crate::bbu::PtrSize>(p: &crate::platform::Platform) -> T {
         crate::platform::PlatformArch::ChipEightRaw => T::from_int(0x200),
         #[cfg(feature = "chip8")]
         crate::platform::PlatformArch::ChipEight => T::from_int(0x200),
-        _ => panic!("unknown arch"),
+        _ => lpanic("rawbin: unknown arch"),
     }
 }
 

--- a/src/eaf.rs
+++ b/src/eaf.rs
@@ -40,6 +40,7 @@ use std::str::FromStr;
 pub fn assemble_full_source(src: &String, pl: &crate::platform::Platform) -> Vec<u8> {
     let mut p: crate::parser::Parser = crate::parser::Parser::from_str(src).unwrap();
     p.parse_all();
+    log::trace!("eaf: parser stage completed, assembling file");
     // if only rust could return types from matches...
     match pl.arch {
         #[cfg(feature = "chip8-raw")]


### PR DESCRIPTION
This patchset finally does away with all non-dead uses of `panic`, switching them over to `lpanic`. It also adds a low-overhead trace log in EAF. Future logging needs more discussion and an option to compile out entirely.

Signed-off-by: Amy Parker <apark0006@student.cerritos.edu>