### PR TITLE
ArchMcrInst implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libxas"
 # v1.0 will be the first "production-ready" version
-version = "0.0.1"
+version = "0.1.0-rc2+"
 edition = "2021"
 authors = ["Amy Parker <apark0006@student.cerritos.edu>"]
 description = "Extendable Assembler library"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libxas"
 # v1.0 will be the first "production-ready" version
-version = "0.1.0-rc2+"
+version = "0.1.0-rc2x"
 edition = "2021"
 authors = ["Amy Parker <apark0006@student.cerritos.edu>"]
 description = "Extendable Assembler library"
@@ -9,7 +9,7 @@ description = "Extendable Assembler library"
 documentation = "https://docs.rs/libxas"
 # When the README is converted the file name needs to be changed
 # Because of crates we should probably use Markdown
-readme = "README"
+readme = "README.md"
 #homepage =
 repository = "https://github.com/amyipdev/libxas"
 license = "GPL-2.0-or-later"

--- a/src/bbu/chip8.rs
+++ b/src/bbu/chip8.rs
@@ -118,6 +118,6 @@ pub fn get_instruction<T: crate::bbu::SymConv>(
     }
 }
 
-pub fn get_macro(i: crate::parser::ParsedMacro) -> Box<dyn ArchMacro> {
+pub fn get_macro<T: crate::bbu::SymConv>(i: crate::parser::ParsedMacro) -> Box<dyn crate::bbu::ArchMcrInst<T>> {
     chip8_raw::get_macro(i)
 }

--- a/src/bbu/chip8.rs
+++ b/src/bbu/chip8.rs
@@ -118,6 +118,8 @@ pub fn get_instruction<T: crate::bbu::SymConv>(
     }
 }
 
-pub fn get_macro<T: crate::bbu::SymConv>(i: crate::parser::ParsedMacro) -> Box<dyn crate::bbu::ArchMcrInst<T>> {
+pub fn get_macro<T: crate::bbu::SymConv>(
+    i: crate::parser::ParsedMacro,
+) -> Box<dyn crate::bbu::ArchMcrInst<T>> {
     chip8_raw::get_macro(i)
 }

--- a/src/bbu/chip8_raw.rs
+++ b/src/bbu/chip8_raw.rs
@@ -281,6 +281,7 @@ macro_rules! make_std_xnn {
                 let b: (Chip8ArchReg, Chip8SymAlias) = get_xnn(a);
                 Self { x: b.0, d: b.1 }
             }
+            // TODO: better optimize this
             fn check_symbols(&self) -> bool {
                 match self.d {
                     crate::bbu::ArgSymbol::UnknownData(_) => true,
@@ -582,7 +583,7 @@ macro_rules! gmm {
 // TODO FIXME: add symbols to macros
 pub fn get_macro<T: crate::bbu::SymConv>(i: crate::parser::ParsedMacro) -> Box<dyn ArchMcrInst<T>> {
     match i.mcr.to_lowercase().as_str() {
-        "byte" => gmm!(BigByte, i),
+        "byte" => gmm!(Bu8, i),
         _ => lpanic("macro not supported"),
     }
 }

--- a/src/bbu/chip8_raw.rs
+++ b/src/bbu/chip8_raw.rs
@@ -571,13 +571,13 @@ fn argcheck(a: &Option<Vec<String>>, i: usize) -> Vec<Chip8Arg> {
 
 macro_rules! gmm {
     ($n:ident,$i:ident) => {{
-        Box::new(<crate::bbu::$n as ArchMacro>::get_lex($i.args))
+        Box::new(<crate::bbu::$n as ArchMcrInst<Chip8Symbol>>::get_lex($i.args))
     }};
 }
 
 // TODO: consider putting these in lexer maybe? idk
 // TODO FIXME: add symbols to macros
-pub fn get_macro(i: crate::parser::ParsedMacro) -> Box<dyn ArchMacro> {
+pub fn get_macro<T: crate::bbu::SymConv>(i: crate::parser::ParsedMacro) -> Box<dyn ArchMcrInst<T>> {
     match i.mcr.to_lowercase().as_str() {
         "byte" => gmm!(BigByte, i),
         _ => lpanic("macro not supported"),

--- a/src/bbu/chip8_raw.rs
+++ b/src/bbu/chip8_raw.rs
@@ -33,8 +33,8 @@ use std::str::FromStr;
 
 // TODO: better error handling
 // TODO: reduce repetition of this
-use crate::bbu::ArchMcrInst;
 use crate::bbu::ArchMacro;
+use crate::bbu::ArchMcrInst;
 
 // TODO: push the shortening out throughout the file
 // TODO: and same with this:
@@ -182,7 +182,8 @@ fn chip8_placeholder() -> Vec<u8> {
 }
 
 // TODO: review of public vs pub(crate) vs private api
-const CHIP8_INSTR_LEN: u8 = 2u8;
+// TODO: refactor to Chip8InstrLen
+const CHIP8_INSTR_LEN: crate::bbu::SymbolPosition = 0x2;
 
 // lots of code duplication with get_output_bytes TODO FIXME NOTE, somen with get_lex
 
@@ -571,7 +572,9 @@ fn argcheck(a: &Option<Vec<String>>, i: usize) -> Vec<Chip8Arg> {
 
 macro_rules! gmm {
     ($n:ident,$i:ident) => {{
-        Box::new(<crate::bbu::$n as ArchMcrInst<Chip8Symbol>>::get_lex($i.args))
+        Box::new(<crate::bbu::$n as ArchMcrInst<Chip8Symbol>>::get_lex(
+            $i.args,
+        ))
     }};
 }
 

--- a/src/bbu/chip8_raw.rs
+++ b/src/bbu/chip8_raw.rs
@@ -584,6 +584,7 @@ macro_rules! gmm {
 pub fn get_macro<T: crate::bbu::SymConv>(i: crate::parser::ParsedMacro) -> Box<dyn ArchMcrInst<T>> {
     match i.mcr.to_lowercase().as_str() {
         "byte" => gmm!(Bu8, i),
+        "word" => gmm!(Bu16, i),
         _ => lpanic("macro not supported"),
     }
 }

--- a/src/bbu/mod.rs
+++ b/src/bbu/mod.rs
@@ -538,7 +538,7 @@ macro_rules! be_mcr {
             x: ArgSymbol<GenScal<$u>, GenScal<$u>>,
         }
         impl<T: SymConv> ArchMcrInst<T> for $nm {
-            fn get_output_bytes(&self) -> Vec<$u> {
+            fn get_output_bytes(&self) -> Vec<u8> {
                 Vec::from(self.x.unwrap_ptr().unwrap().i.to_be_bytes())
             }
             fn get_lex(a: Option<Vec<String>>) -> Self {
@@ -602,4 +602,5 @@ macro_rules! le_mcr {
 }
 
 be_mcr!(Bu8, u8);
+be_mcr!(Bu16, u16);
 //be_mcr!(BigWord, u16);

--- a/src/bbu/mod.rs
+++ b/src/bbu/mod.rs
@@ -525,7 +525,7 @@ macro_rules! be_mcr {
         pub struct $nm {
             x: $u,
         }
-        impl ArchMacro for $nm {
+        impl<T: SymConv> ArchMcrInst<T> for $nm {
             fn get_output_bytes(&self) -> Vec<$u> {
                 Vec::from(self.x.to_be_bytes())
             }
@@ -535,6 +535,10 @@ macro_rules! be_mcr {
                 }
             }
             fn get_length(&self) -> SymbolPosition {$len}
+            fn get_symbols(&self) -> USIWrap {unimplemented!()}
+            fn get_placeholder(&self) -> Vec<u8> {unimplemented!()}
+            fn fulfill_symbol(&mut self, s: &T, p: SymbolPosition) -> () {unimplemented!()}
+            fn check_symbols(&self) -> bool {false}
         }
     };
 }

--- a/src/bbu/outs/rawbin.rs
+++ b/src/bbu/outs/rawbin.rs
@@ -175,8 +175,7 @@ pub fn run_output<T: crate::bbu::SymConv, U: crate::bbu::PtrSize>(
                             dt.push(OptionLeaf::Symbol(n))
                         }
                         l
-                    }
-                    //_ => lpanic("unsupported op type"),
+                    } //_ => lpanic("unsupported op type"),
                 };
                 cp.add_int(b);
             }

--- a/src/eaf.rs
+++ b/src/eaf.rs
@@ -45,20 +45,15 @@ pub fn assemble_full_source(src: &String, pl: &crate::platform::Platform) -> Vec
     match pl.arch {
         // code dup bt c8r, c8 TODO
         #[cfg(feature = "chip8-raw")]
-        crate::platform::PlatformArch::ChipEightRaw => {
-            assemble_full_source_gen::<
-                crate::bbu::chip8_raw::Chip8Symbol,
-                crate::bbu::chip8_raw::Chip8PtrSize,
-            >(p.pop_vdq(), pl)
-        }
+        crate::platform::PlatformArch::ChipEightRaw => assemble_full_source_gen::<
+            crate::bbu::chip8_raw::Chip8Symbol,
+            crate::bbu::chip8_raw::Chip8PtrSize,
+        >(p.pop_vdq(), pl),
         #[cfg(feature = "chip8")]
-        crate::platform::PlatformArch::ChipEight => {
-            assemble_full_source_gen::<
-                crate::bbu::chip8_raw::Chip8Symbol,
-                crate::bbu::chip8_raw::Chip8PtrSize,
-            >(p.pop_vdq(), pl)
-        }
-        //_ => panic!("unknown arch")
+        crate::platform::PlatformArch::ChipEight => assemble_full_source_gen::<
+            crate::bbu::chip8_raw::Chip8Symbol,
+            crate::bbu::chip8_raw::Chip8PtrSize,
+        >(p.pop_vdq(), pl), //_ => panic!("unknown arch")
     }
 }
 

--- a/src/eaf.rs
+++ b/src/eaf.rs
@@ -43,8 +43,16 @@ pub fn assemble_full_source(src: &String, pl: &crate::platform::Platform) -> Vec
     log::trace!("eaf: parser stage completed, assembling file");
     // if only rust could return types from matches...
     match pl.arch {
+        // code dup bt c8r, c8 TODO
         #[cfg(feature = "chip8-raw")]
-        crate::platform::PlatformArch::ChipEightRaw | crate::platform::PlatformArch::ChipEight => {
+        crate::platform::PlatformArch::ChipEightRaw => {
+            assemble_full_source_gen::<
+                crate::bbu::chip8_raw::Chip8Symbol,
+                crate::bbu::chip8_raw::Chip8PtrSize,
+            >(p.pop_vdq(), pl)
+        }
+        #[cfg(feature = "chip8")]
+        crate::platform::PlatformArch::ChipEight => {
             assemble_full_source_gen::<
                 crate::bbu::chip8_raw::Chip8Symbol,
                 crate::bbu::chip8_raw::Chip8PtrSize,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -305,11 +305,11 @@ impl<T: crate::bbu::SymConv> Lexer<T> {
             let op: LexOperation<T> = match self.p.arch {
                 #[cfg(feature = "chip8-raw")]
                 crate::platform::PlatformArch::ChipEightRaw => {
-                    LexOperation::Macro(crate::bbu::chip8_raw::get_macro(i))
+                    LexOperation::Instruction(crate::bbu::chip8_raw::get_macro(i))
                 }
                 #[cfg(feature = "chip8")]
                 crate::platform::PlatformArch::ChipEight => {
-                    LexOperation::Macro(crate::bbu::chip8::get_macro(i))
+                    LexOperation::Instruction(crate::bbu::chip8::get_macro(i))
                 }
                 //_ => panic!("not implemented yet")
             };

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -253,7 +253,7 @@ impl<T: crate::bbu::SymConv> Lexer<T> {
                 // adding a flag of some kind to LexSection?
                 // TODO: better matching system if not, this needs overhaul
                 match j.mcr.to_lowercase().as_str() {
-                    "byte" => {
+                    "byte" | "word" => {
                         self.push_macro(j);
                     }
                     "label" | "lbl" => {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -310,8 +310,7 @@ impl<T: crate::bbu::SymConv> Lexer<T> {
                 #[cfg(feature = "chip8")]
                 crate::platform::PlatformArch::ChipEight => {
                     LexOperation::Instruction(crate::bbu::chip8::get_macro(i))
-                }
-                //_ => panic!("not implemented yet")
+                } //_ => panic!("not implemented yet")
             };
             match j {
                 LexLabelType::Base(ref mut a) => a,
@@ -339,8 +338,7 @@ impl<T: crate::bbu::SymConv> Lexer<T> {
                 #[cfg(feature = "chip8")]
                 crate::platform::PlatformArch::ChipEight => {
                     LexOperation::Instruction(crate::bbu::chip8::get_instruction::<T>(i))
-                }
-                //_ => panic!("architecture not implemented yet"),
+                } //_ => panic!("architecture not implemented yet"),
             };
             match j {
                 LexLabelType::Base(ref mut a) => a,


### PR DESCRIPTION
This is the FWV of the macro-on-archmcrinst implementation, which allows macros to use symbols. There's still cleanup (in particular in Lexer) which needs to happen; getting rid of LexOperation as an abstraction layer is also a possibility. However, everything works at this point.

Signed-off-by: Amy Parker <apark0006@student.cerritos.edu>
Fixes: #11 