### PR TITLE
lexer: remove LexOp::Macro

### DIFF
--- a/src/bbu/outs/rawbin.rs
+++ b/src/bbu/outs/rawbin.rs
@@ -161,11 +161,11 @@ pub fn run_output<T: crate::bbu::SymConv, U: crate::bbu::PtrSize>(
             for op in label_parts.0 {
                 let b = match op {
                     // macros will be dead soon anyways
-                    crate::lexer::LexOperation::Macro(m) => {
-                        let l = m.get_length();
-                        dt.push(OptionLeaf::Constant(m.get_output_bytes()));
-                        l
-                    }
+                    //crate::lexer::LexOperation::Macro(m) => {
+                    //    let l = m.get_length();
+                    //    dt.push(OptionLeaf::Constant(m.get_output_bytes()));
+                    //    l
+                    //}
                     crate::lexer::LexOperation::Instruction(n) => {
                         let l = n.get_length(); // pre-save before move
                         if !n.check_symbols() {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -65,9 +65,12 @@ use crate::errors::lpanic;
 // for sections like rodata and BSS. Flags are set based on input ID
 // type from platform.
 
+// TODO: consider phasing out LexOperation, as is no longer necessary
+// keeping things wrapped inside a single-item enum doesn't particularly
+// make much sense
 pub enum LexOperation<T: crate::bbu::SymConv> {
     Instruction(Box<dyn crate::bbu::ArchMcrInst<T>>),
-    Macro(Box<dyn crate::bbu::ArchMacro>),
+    //Macro(Box<dyn crate::bbu::ArchMacro>),
 }
 
 impl<T: crate::bbu::SymConv> std::fmt::Debug for LexOperation<T> {
@@ -76,7 +79,7 @@ impl<T: crate::bbu::SymConv> std::fmt::Debug for LexOperation<T> {
             LexOperation::Instruction(ref i) => {
                 write!(f, "ArchMcrInst: {:02x?}", i.get_output_bytes())
             }
-            LexOperation::Macro(ref j) => write!(f, "ArchMacro: {:02x?}", j.get_output_bytes()),
+            //LexOperation::Macro(ref j) => write!(f, "ArchMacro: {:02x?}", j.get_output_bytes()),
         }
     }
 }
@@ -92,7 +95,7 @@ impl<T: crate::bbu::SymConv> LexOperation<T> {
     pub fn extract_bytes(&self) -> Vec<u8> {
         match self {
             LexOperation::Instruction(a) => a.get_output_bytes(),
-            LexOperation::Macro(b) => b.get_output_bytes(),
+            //LexOperation::Macro(b) => b.get_output_bytes(),
         }
     }
 }


### PR DESCRIPTION
This patch finally gets rid of the Macro enum-part in LexOperation. There's still other associated cleanup that needs to be done - and we really need to consider getting rid of LexOp altogether - but this is a start which should shave some bloat off. The code has just been commented out for now in case it needs to be reenabled in the future.

Signed-off-by: Amy Parker <apark0006@student.cerritos.edu>