### PR TITLE
bbu: temporarily disable lemcr

### DIFF
--- a/src/bbu/mod.rs
+++ b/src/bbu/mod.rs
@@ -579,6 +579,7 @@ macro_rules! be_mcr {
     };
 }
 
+/*
 macro_rules! le_mcr {
     ($nm:ident,$u:ty,$len:expr) => {
         pub struct $nm {
@@ -599,7 +600,7 @@ macro_rules! le_mcr {
             }
         }
     };
-}
+}*/
 
 be_mcr!(Bu8, u8);
 be_mcr!(Bu16, u16);

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -253,6 +253,9 @@ impl<T: crate::bbu::SymConv> Lexer<T> {
                 // adding a flag of some kind to LexSection?
                 // TODO: better matching system if not, this needs overhaul
                 match j.mcr.to_lowercase().as_str() {
+                    // TODO: we need to consider just having this
+                    // case be the fallback case, without any explicit matching
+                    // let architectures implement what they want
                     "byte" | "word" => {
                         self.push_macro(j);
                     }


### PR DESCRIPTION
This patch temporarily disables lemcr; it will be reenabled later, but it doesn't need to be compiled through when the only supported architectures are BE ones.

This patch also leaves a comment in Lexer about future decisions on how to handle case matching for macros.

Signed-off-by: Amy Parker <apark0006@student.cerritos.edu>