### PR TITLE
bbu: deadcode ArchMacro

### DIFF
--- a/src/bbu/chip8.rs
+++ b/src/bbu/chip8.rs
@@ -24,7 +24,7 @@
 use crate::bbu::chip8_raw;
 use crate::errors::lpanic;
 
-use crate::bbu::ArchMacro;
+//use crate::bbu::ArchMacro;
 
 // TODO: utility, global it - readd in p
 // TODO: probably a better way than this

--- a/src/bbu/chip8_raw.rs
+++ b/src/bbu/chip8_raw.rs
@@ -33,7 +33,7 @@ use std::str::FromStr;
 
 // TODO: better error handling
 // TODO: reduce repetition of this
-use crate::bbu::ArchMacro;
+//use crate::bbu::ArchMacro;
 use crate::bbu::ArchMcrInst;
 
 // TODO: push the shortening out throughout the file

--- a/src/bbu/mod.rs
+++ b/src/bbu/mod.rs
@@ -98,6 +98,7 @@ pub trait ArchMcrInst<T: SymConv> {
         Self: Sized;
 }
 
+/*
 // TODO FIXME: support symbols in macros
 pub trait ArchMacro {
     fn get_output_bytes(&self) -> Vec<u8>;
@@ -105,7 +106,7 @@ pub trait ArchMacro {
     where
         Self: Sized;
     fn get_length(&self) -> SymbolPosition;
-}
+}*/
 
 // TODO NOTE FIXME consider refactoring all of this into parser, so it happens pre-lexing?? maybe??
 


### PR DESCRIPTION
Now that all macros run on ArchMcrInst, ArchMacro is unnecessary. This patch removes ArchMacro, commenting it out for now; these blocks should be scraped out in the next dead code cleanup.

Signed-off-by: Amy Parker <apark0006@student.cerritos.edu>